### PR TITLE
Use cached network images with placeholders

### DIFF
--- a/lib/components/create_note_widget.dart
+++ b/lib/components/create_note_widget.dart
@@ -7,6 +7,7 @@ import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/flutter_flow/form_field_controller.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -143,14 +144,19 @@ class _CreateNoteWidgetState extends State<CreateNoteWidget> {
                   children: [
                     ClipRRect(
                       borderRadius: BorderRadius.circular(40),
-                      child: Image.network(
-                        valueOrDefault<String>(
+                      child: CachedNetworkImage(
+                        imageUrl: valueOrDefault<String>(
                           widget.userImage,
                           'https://images.unsplash.com/photo-1610737241336-371badac3b66?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NDV8fHVzZXJ8ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60',
                         ),
                         width: 40,
                         height: 40,
                         fit: BoxFit.cover,
+                        placeholder: (context, url) => const Center(
+                          child: CircularProgressIndicator(),
+                        ),
+                        errorWidget: (context, url, error) =>
+                            const Icon(Icons.error),
                       ),
                     ),
                     Padding(

--- a/lib/edit_profile/edit_profile_widget.dart
+++ b/lib/edit_profile/edit_profile_widget.dart
@@ -7,6 +7,7 @@ import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/flutter_flow/upload_data.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -124,11 +125,16 @@ class _EditProfileWidgetState extends State<EditProfileWidget> {
                             decoration: BoxDecoration(
                               shape: BoxShape.circle,
                             ),
-                            child: Image.network(
-                              valueOrDefault<String>(
+                            child: CachedNetworkImage(
+                              imageUrl: valueOrDefault<String>(
                                 _model.uploadedFileUrl,
                                 'https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTE1fHx1c2VyfGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=800&q=60',
                               ),
+                              placeholder: (context, url) => const Center(
+                                child: CircularProgressIndicator(),
+                              ),
+                              errorWidget: (context, url, error) =>
+                                  const Icon(Icons.error),
                             ),
                           ),
                         ),

--- a/lib/home/home/home_widget.dart
+++ b/lib/home/home/home_widget.dart
@@ -8,6 +8,7 @@ import '/flutter_flow/custom_functions.dart' as functions;
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -329,11 +330,19 @@ class _HomeWidgetState extends State<HomeWidget> {
                                                 ClipRRect(
                                                   borderRadius:
                                                       BorderRadius.circular(10),
-                                                  child: Image.network(
-                                                    'https://images.unsplash.com/photo-1600335895229-6e75511892c8?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
+                                                  child: CachedNetworkImage(
+                                                    imageUrl:
+                                                        'https://images.unsplash.com/photo-1600335895229-6e75511892c8?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
                                                     width: double.infinity,
                                                     height: 105,
                                                     fit: BoxFit.fitWidth,
+                                                    placeholder: (context, url) =>
+                                                        const Center(
+                                                      child:
+                                                          CircularProgressIndicator(),
+                                                    ),
+                                                    errorWidget: (context, url, error) =>
+                                                        const Icon(Icons.error),
                                                   ),
                                                 ),
                                                 Padding(
@@ -445,11 +454,19 @@ class _HomeWidgetState extends State<HomeWidget> {
                                                 ClipRRect(
                                                   borderRadius:
                                                       BorderRadius.circular(10),
-                                                  child: Image.network(
-                                                    'https://images.unsplash.com/photo-1497534446932-c925b458314e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1372&q=80',
+                                                  child: CachedNetworkImage(
+                                                    imageUrl:
+                                                        'https://images.unsplash.com/photo-1497534446932-c925b458314e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1372&q=80',
                                                     width: double.infinity,
                                                     height: 105,
                                                     fit: BoxFit.fitWidth,
+                                                    placeholder: (context, url) =>
+                                                        const Center(
+                                                      child:
+                                                          CircularProgressIndicator(),
+                                                    ),
+                                                    errorWidget: (context, url, error) =>
+                                                        const Icon(Icons.error),
                                                   ),
                                                 ),
                                                 Padding(
@@ -561,11 +578,19 @@ class _HomeWidgetState extends State<HomeWidget> {
                                                 ClipRRect(
                                                   borderRadius:
                                                       BorderRadius.circular(10),
-                                                  child: Image.network(
-                                                    'https://images.unsplash.com/photo-1565958011703-44f9829ba187?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8N3x8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+                                                  child: CachedNetworkImage(
+                                                    imageUrl:
+                                                        'https://images.unsplash.com/photo-1565958011703-44f9829ba187?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8N3x8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
                                                     width: double.infinity,
                                                     height: 105,
                                                     fit: BoxFit.fitWidth,
+                                                    placeholder: (context, url) =>
+                                                        const Center(
+                                                      child:
+                                                          CircularProgressIndicator(),
+                                                    ),
+                                                    errorWidget: (context, url, error) =>
+                                                        const Icon(Icons.error),
                                                   ),
                                                 ),
                                                 Padding(
@@ -677,11 +702,19 @@ class _HomeWidgetState extends State<HomeWidget> {
                                                 ClipRRect(
                                                   borderRadius:
                                                       BorderRadius.circular(10),
-                                                  child: Image.network(
-                                                    'https://images.unsplash.com/photo-1493770348161-369560ae357d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80',
+                                                  child: CachedNetworkImage(
+                                                    imageUrl:
+                                                        'https://images.unsplash.com/photo-1493770348161-369560ae357d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80',
                                                     width: double.infinity,
                                                     height: 105,
                                                     fit: BoxFit.fitWidth,
+                                                    placeholder: (context, url) =>
+                                                        const Center(
+                                                      child:
+                                                          CircularProgressIndicator(),
+                                                    ),
+                                                    errorWidget: (context, url, error) =>
+                                                        const Icon(Icons.error),
                                                   ),
                                                 ),
                                                 Padding(
@@ -793,11 +826,19 @@ class _HomeWidgetState extends State<HomeWidget> {
                                                 ClipRRect(
                                                   borderRadius:
                                                       BorderRadius.circular(10),
-                                                  child: Image.network(
-                                                    'https://images.unsplash.com/photo-1504674900247-0877df9cc836?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+                                                  child: CachedNetworkImage(
+                                                    imageUrl:
+                                                        'https://images.unsplash.com/photo-1504674900247-0877df9cc836?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
                                                     width: double.infinity,
                                                     height: 105,
                                                     fit: BoxFit.fitWidth,
+                                                    placeholder: (context, url) =>
+                                                        const Center(
+                                                      child:
+                                                          CircularProgressIndicator(),
+                                                    ),
+                                                    errorWidget: (context, url, error) =>
+                                                        const Icon(Icons.error),
                                                   ),
                                                 ),
                                                 Padding(
@@ -1085,16 +1126,25 @@ class _HomeWidgetState extends State<HomeWidget> {
                                                                     .circular(
                                                                         10),
                                                             child:
-                                                                Image.network(
-                                                              getJsonField(
+                                                                CachedNetworkImage(
+                                                              imageUrl:
+                                                                  getJsonField(
                                                                 recipeItem,
                                                                 r'''$.image''',
-                                                              ),
+                                                              ).toString(),
                                                               width: double
                                                                   .infinity,
                                                               height: 155,
                                                               fit: BoxFit
                                                                   .fitWidth,
+                                                              placeholder: (context, url) =>
+                                                                  const Center(
+                                                                child:
+                                                                    CircularProgressIndicator(),
+                                                              ),
+                                                              errorWidget:
+                                                                  (context, url, error) =>
+                                                                      const Icon(Icons.error),
                                                             ),
                                                           ),
                                                           Row(

--- a/lib/home/home_copy/home_copy_widget.dart
+++ b/lib/home/home_copy/home_copy_widget.dart
@@ -3,6 +3,7 @@ import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -237,11 +238,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1504674900247-0877df9cc836?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1504674900247-0877df9cc836?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -310,11 +317,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -383,11 +396,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1565958011703-44f9829ba187?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8N3x8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1565958011703-44f9829ba187?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8N3x8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -456,11 +475,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1476224203421-9ac39bcb3327?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTl8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1476224203421-9ac39bcb3327?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTl8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -529,11 +554,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1504754524776-8f4f37790ca0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTd8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1504754524776-8f4f37790ca0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTd8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -602,11 +633,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1484980972926-edee96e0960d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MjN8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1484980972926-edee96e0960d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MjN8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(

--- a/lib/home_copy/home_copy_widget.dart
+++ b/lib/home_copy/home_copy_widget.dart
@@ -3,6 +3,7 @@ import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -237,11 +238,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1504674900247-0877df9cc836?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1504674900247-0877df9cc836?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -310,11 +317,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NXx8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -383,11 +396,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1565958011703-44f9829ba187?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8N3x8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1565958011703-44f9829ba187?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8N3x8Zm9vZHxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -456,11 +475,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1476224203421-9ac39bcb3327?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTl8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1476224203421-9ac39bcb3327?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTl8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -529,11 +554,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1504754524776-8f4f37790ca0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTd8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1504754524776-8f4f37790ca0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTd8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(
@@ -602,11 +633,17 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                           children: [
                             ClipRRect(
                               borderRadius: BorderRadius.circular(10.0),
-                              child: Image.network(
-                                'https://images.unsplash.com/photo-1484980972926-edee96e0960d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MjN8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    'https://images.unsplash.com/photo-1484980972926-edee96e0960d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MjN8fGZvb2R8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
                                 width: double.infinity,
                                 height: 115.0,
                                 fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                  child: CircularProgressIndicator(),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
                               ),
                             ),
                             Padding(

--- a/lib/meal_type_pages/beverages/beverages_widget.dart
+++ b/lib/meal_type_pages/beverages/beverages_widget.dart
@@ -7,6 +7,7 @@ import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/custom_functions.dart' as functions;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
@@ -480,15 +481,23 @@ class _BeveragesWidgetState extends State<BeveragesWidget> {
                                                           borderRadius:
                                                               BorderRadius
                                                                   .circular(10),
-                                                          child: Image.network(
-                                                            getJsonField(
+                                                          child: CachedNetworkImage(
+                                                            imageUrl: getJsonField(
                                                               recipesItem,
                                                               r'''$.image''',
-                                                            ),
+                                                            ).toString(),
                                                             width:
                                                                 double.infinity,
                                                             height: 115,
                                                             fit: BoxFit.cover,
+                                                            placeholder: (context, url) =>
+                                                                const Center(
+                                                              child:
+                                                                  CircularProgressIndicator(),
+                                                            ),
+                                                            errorWidget:
+                                                                (context, url, error) =>
+                                                                    const Icon(Icons.error),
                                                           ),
                                                         ),
                                                         Expanded(

--- a/lib/meal_type_pages/breakfast/breakfast_widget.dart
+++ b/lib/meal_type_pages/breakfast/breakfast_widget.dart
@@ -8,6 +8,7 @@ import '/flutter_flow/custom_functions.dart' as functions;
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
@@ -480,15 +481,23 @@ class _BreakfastWidgetState extends State<BreakfastWidget> {
                                                           borderRadius:
                                                               BorderRadius
                                                                   .circular(10),
-                                                          child: Image.network(
-                                                            getJsonField(
+                                                          child: CachedNetworkImage(
+                                                            imageUrl: getJsonField(
                                                               recipesItem,
                                                               r'''$.image''',
-                                                            ),
+                                                            ).toString(),
                                                             width:
                                                                 double.infinity,
                                                             height: 115,
                                                             fit: BoxFit.cover,
+                                                            placeholder: (context, url) =>
+                                                                const Center(
+                                                              child:
+                                                                  CircularProgressIndicator(),
+                                                            ),
+                                                            errorWidget:
+                                                                (context, url, error) =>
+                                                                    const Icon(Icons.error),
                                                           ),
                                                         ),
                                                         Expanded(

--- a/lib/meal_type_pages/dessert/dessert_widget.dart
+++ b/lib/meal_type_pages/dessert/dessert_widget.dart
@@ -7,6 +7,7 @@ import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/custom_functions.dart' as functions;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
@@ -479,15 +480,23 @@ class _DessertWidgetState extends State<DessertWidget> {
                                                           borderRadius:
                                                               BorderRadius
                                                                   .circular(10),
-                                                          child: Image.network(
-                                                            getJsonField(
+                                                          child: CachedNetworkImage(
+                                                            imageUrl: getJsonField(
                                                               recipesItem,
                                                               r'''$.image''',
-                                                            ),
+                                                            ).toString(),
                                                             width:
                                                                 double.infinity,
                                                             height: 115,
                                                             fit: BoxFit.cover,
+                                                            placeholder: (context, url) =>
+                                                                const Center(
+                                                              child:
+                                                                  CircularProgressIndicator(),
+                                                            ),
+                                                            errorWidget:
+                                                                (context, url, error) =>
+                                                                    const Icon(Icons.error),
                                                           ),
                                                         ),
                                                         Expanded(

--- a/lib/meal_type_pages/main_course/main_course_widget.dart
+++ b/lib/meal_type_pages/main_course/main_course_widget.dart
@@ -7,6 +7,7 @@ import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/custom_functions.dart' as functions;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
@@ -479,15 +480,23 @@ class _MainCourseWidgetState extends State<MainCourseWidget> {
                                                           borderRadius:
                                                               BorderRadius
                                                                   .circular(10),
-                                                          child: Image.network(
-                                                            getJsonField(
+                                                          child: CachedNetworkImage(
+                                                            imageUrl: getJsonField(
                                                               recipesItem,
                                                               r'''$.image''',
-                                                            ),
+                                                            ).toString(),
                                                             width:
                                                                 double.infinity,
                                                             height: 115,
                                                             fit: BoxFit.cover,
+                                                            placeholder: (context, url) =>
+                                                                const Center(
+                                                              child:
+                                                                  CircularProgressIndicator(),
+                                                            ),
+                                                            errorWidget:
+                                                                (context, url, error) =>
+                                                                    const Icon(Icons.error),
                                                           ),
                                                         ),
                                                         Expanded(

--- a/lib/meal_type_pages/salad/salad_widget.dart
+++ b/lib/meal_type_pages/salad/salad_widget.dart
@@ -7,6 +7,7 @@ import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/custom_functions.dart' as functions;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
@@ -477,15 +478,23 @@ class _SaladWidgetState extends State<SaladWidget> {
                                                           borderRadius:
                                                               BorderRadius
                                                                   .circular(10),
-                                                          child: Image.network(
-                                                            getJsonField(
+                                                          child: CachedNetworkImage(
+                                                            imageUrl: getJsonField(
                                                               recipesItem,
                                                               r'''$.image''',
-                                                            ),
+                                                            ).toString(),
                                                             width:
                                                                 double.infinity,
                                                             height: 115,
                                                             fit: BoxFit.cover,
+                                                            placeholder: (context, url) =>
+                                                                const Center(
+                                                              child:
+                                                                  CircularProgressIndicator(),
+                                                            ),
+                                                            errorWidget:
+                                                                (context, url, error) =>
+                                                                    const Icon(Icons.error),
                                                           ),
                                                         ),
                                                         Expanded(

--- a/lib/profile_pages/edit_profile/edit_profile_widget.dart
+++ b/lib/profile_pages/edit_profile/edit_profile_widget.dart
@@ -7,6 +7,7 @@ import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/flutter_flow/upload_data.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -124,11 +125,16 @@ class _EditProfileWidgetState extends State<EditProfileWidget> {
                             decoration: BoxDecoration(
                               shape: BoxShape.circle,
                             ),
-                            child: Image.network(
-                              valueOrDefault<String>(
+                            child: CachedNetworkImage(
+                              imageUrl: valueOrDefault<String>(
                                 _model.uploadedFileUrl,
                                 'https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTE1fHx1c2VyfGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=800&q=60',
                               ),
+                              placeholder: (context, url) => const Center(
+                                child: CircularProgressIndicator(),
+                              ),
+                              errorWidget: (context, url, error) =>
+                                  const Icon(Icons.error),
                             ),
                           ),
                         ),

--- a/lib/profile_pages/profile_page/profile_page_widget.dart
+++ b/lib/profile_pages/profile_page/profile_page_widget.dart
@@ -4,6 +4,7 @@ import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/flutter_flow/custom_functions.dart' as functions;
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -103,13 +104,20 @@ class _ProfilePageWidgetState extends State<ProfilePageWidget> {
                                       builder: (context) => ClipRRect(
                                         borderRadius:
                                             BorderRadius.circular(50.0),
-                                        child: Image.network(
-                                          valueOrDefault<String>(
+                                        child: CachedNetworkImage(
+                                          imageUrl: valueOrDefault<String>(
                                             currentUserPhoto,
                                             'https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTE1fHx1c2VyfGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=800&q=60',
                                           ),
                                           width: double.infinity,
                                           fit: BoxFit.fitWidth,
+                                          placeholder: (context, url) =>
+                                              const Center(
+                                            child:
+                                                CircularProgressIndicator(),
+                                          ),
+                                          errorWidget: (context, url, error) =>
+                                              const Icon(Icons.error),
                                         ),
                                       ),
                                     ),

--- a/lib/recipe_pages/details_screen/details_screen_widget.dart
+++ b/lib/recipe_pages/details_screen/details_screen_widget.dart
@@ -8,6 +8,7 @@ import '/flutter_flow/flutter_flow_widgets.dart';
 import '/flutter_flow/custom_functions.dart' as functions;
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -97,15 +98,21 @@ class _DetailsScreenWidgetState extends State<DetailsScreenWidget> {
                                 children: [
                                   Align(
                                     alignment: AlignmentDirectional(0.0, 0.0),
-                                    child: Image.network(
-                                      RecipeInfoCall.image(
+                                    child: CachedNetworkImage(
+                                      imageUrl: RecipeInfoCall.image(
                                         detailsScreenRecipeInfoResponse
                                             .jsonBody,
-                                      ),
+                                      ).toString(),
                                       width: MediaQuery.of(context).size.width *
                                           1.0,
                                       height: 240.0,
                                       fit: BoxFit.cover,
+                                      placeholder: (context, url) => const Center(
+                                        child: CircularProgressIndicator(),
+                                      ),
+                                      errorWidget:
+                                          (context, url, error) =>
+                                              const Icon(Icons.error),
                                     ),
                                   ),
                                   Builder(

--- a/lib/recipe_pages/details_screen_database/details_screen_database_widget.dart
+++ b/lib/recipe_pages/details_screen_database/details_screen_database_widget.dart
@@ -10,6 +10,7 @@ import '/flutter_flow/custom_functions.dart' as functions;
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -116,12 +117,18 @@ class _DetailsScreenDatabaseWidgetState
                                 children: [
                                   Align(
                                     alignment: AlignmentDirectional(0, -1.13),
-                                    child: Image.network(
-                                      detailsScreenDatabaseRecipesRecord!
-                                          .recipeImage!,
+                                    child: CachedNetworkImage(
+                                      imageUrl:
+                                          detailsScreenDatabaseRecipesRecord!
+                                              .recipeImage!,
                                       width: MediaQuery.of(context).size.width,
                                       height: 179,
                                       fit: BoxFit.cover,
+                                      placeholder: (context, url) => const Center(
+                                        child: CircularProgressIndicator(),
+                                      ),
+                                      errorWidget: (context, url, error) =>
+                                          const Icon(Icons.error),
                                     ),
                                   ),
                                   Builder(
@@ -1388,12 +1395,21 @@ class _DetailsScreenDatabaseWidgetState
                                                                       .circular(
                                                                           40),
                                                               child:
-                                                                  Image.network(
-                                                                'https://images.unsplash.com/photo-1610737241336-371badac3b66?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NDV8fHVzZXJ8ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60',
+                                                                  CachedNetworkImage(
+                                                                imageUrl:
+                                                                    'https://images.unsplash.com/photo-1610737241336-371badac3b66?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NDV8fHVzZXJ8ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60',
                                                                 width: 40,
                                                                 height: 40,
                                                                 fit: BoxFit
                                                                     .cover,
+                                                                placeholder:
+                                                                    (context, url) =>
+                                                                        const Center(
+                                                                  child:
+                                                                      CircularProgressIndicator(),
+                                                                ),
+                                                                errorWidget: (context, url, error) =>
+                                                                    const Icon(Icons.error),
                                                               ),
                                                             ),
                                                             Expanded(
@@ -1861,14 +1877,19 @@ class _DetailsScreenDatabaseWidgetState
                                                                           children: [
                                                                             ClipRRect(
                                                                               borderRadius: BorderRadius.circular(10.0),
-                                                                              child: Image.network(
-                                                                                getJsonField(
+                                                                              child: CachedNetworkImage(
+                                                                                imageUrl: getJsonField(
                                                                                   recipesItem,
                                                                                   r'''$.image''',
-                                                                                ),
+                                                                                ).toString(),
                                                                                 width: double.infinity,
                                                                                 height: 115.0,
                                                                                 fit: BoxFit.cover,
+                                                                                placeholder: (context, url) => const Center(
+                                                                                  child: CircularProgressIndicator(),
+                                                                                ),
+                                                                                errorWidget: (context, url, error) =>
+                                                                                    const Icon(Icons.error),
                                                                               ),
                                                                             ),
                                                                             Expanded(
@@ -2241,12 +2262,21 @@ class _DetailsScreenDatabaseWidgetState
                                                                       .circular(
                                                                           40),
                                                               child:
-                                                                  Image.network(
-                                                                'https://images.unsplash.com/photo-1610737241336-371badac3b66?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NDV8fHVzZXJ8ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60',
+                                                                  CachedNetworkImage(
+                                                                imageUrl:
+                                                                    'https://images.unsplash.com/photo-1610737241336-371badac3b66?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NDV8fHVzZXJ8ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60',
                                                                 width: 40,
                                                                 height: 40,
                                                                 fit: BoxFit
                                                                     .cover,
+                                                                placeholder:
+                                                                    (context, url) =>
+                                                                        const Center(
+                                                                  child:
+                                                                      CircularProgressIndicator(),
+                                                                ),
+                                                                errorWidget: (context, url, error) =>
+                                                                    const Icon(Icons.error),
                                                               ),
                                                             ),
                                                             Expanded(


### PR DESCRIPTION
## Summary
- replace `Image.network` with `CachedNetworkImage` across the app for caching
- add loading placeholders and error icons to network image widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689536adda8c832289899d0d35f581ba