### PR TITLE
Persist app state with SharedPreferences

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'backend/backend.dart';
-import 'backend/api_requests/api_manager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'flutter_flow/flutter_flow_util.dart';
 
@@ -13,7 +11,17 @@ class FFAppState extends ChangeNotifier {
 
   FFAppState._internal();
 
-  Future initializePersistedState() async {}
+  late SharedPreferences _prefs;
+
+  Future initializePersistedState() async {
+    _prefs = await SharedPreferences.getInstance();
+    _queryBeverage = _prefs.getString('ff_queryBeverage') ?? _queryBeverage;
+    _queryBreakfast = _prefs.getString('ff_queryBreakfast') ?? _queryBreakfast;
+    _querySalad = _prefs.getString('ff_querySalad') ?? _querySalad;
+    _queryMainCourse =
+        _prefs.getString('ff_queryMainCourse') ?? _queryMainCourse;
+    _queryDessert = _prefs.getString('ff_queryDessert') ?? _queryDessert;
+  }
 
   void update(VoidCallback callback) {
     callback();
@@ -24,30 +32,35 @@ class FFAppState extends ChangeNotifier {
   String get queryBeverage => _queryBeverage;
   set queryBeverage(String _value) {
     _queryBeverage = _value;
+    _prefs.setString('ff_queryBeverage', _value);
   }
 
   String _queryBreakfast = 'chicken';
   String get queryBreakfast => _queryBreakfast;
   set queryBreakfast(String _value) {
     _queryBreakfast = _value;
+    _prefs.setString('ff_queryBreakfast', _value);
   }
 
   String _querySalad = 'salad';
   String get querySalad => _querySalad;
   set querySalad(String _value) {
     _querySalad = _value;
+    _prefs.setString('ff_querySalad', _value);
   }
 
   String _queryMainCourse = 'chicken';
   String get queryMainCourse => _queryMainCourse;
   set queryMainCourse(String _value) {
     _queryMainCourse = _value;
+    _prefs.setString('ff_queryMainCourse', _value);
   }
 
   String _queryDessert = 'cake';
   String get queryDessert => _queryDessert;
   set queryDessert(String _value) {
     _queryDessert = _value;
+    _prefs.setString('ff_queryDessert', _value);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove unused backend and API imports from app state
- persist query values using SharedPreferences

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689536aea5a0832280e832fbe422d1c0