### PR TITLE
Replace print statements with structured logging

### DIFF
--- a/lib/auth/firebase_auth/firebase_auth_manager.dart
+++ b/lib/auth/firebase_auth/firebase_auth_manager.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, kDebugMode;
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import '../auth_manager.dart';
 import '../base_auth_user_provider.dart';
 import '../../flutter_flow/flutter_flow_util.dart';
+import 'dart:developer' as dev;
 
 import '../../backend/backend.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -41,7 +42,9 @@ class FirebaseAuthManager extends AuthManager
   Future deleteUser(BuildContext context) async {
     try {
       if (!loggedIn) {
-        print('Error: delete user attempted with no logged in user!');
+        if (kDebugMode) {
+          dev.log('Error: delete user attempted with no logged in user!');
+        }
         return;
       }
       await currentUser?.delete();

--- a/lib/backend/backend.dart
+++ b/lib/backend/backend.dart
@@ -4,6 +4,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../auth/firebase_auth/auth_util.dart';
 
 import '../flutter_flow/flutter_flow_util.dart';
+import 'dart:developer' as dev;
+import 'package:flutter/foundation.dart';
 
 import 'schema/recipes_record.dart';
 import 'schema/illnesses_record.dart';
@@ -632,7 +634,9 @@ Future<int> queryCollectionCount(
   }
 
   return query.count().get().catchError((err) {
-    print('Error querying $collection: $err');
+    if (kDebugMode) {
+      dev.log('Error querying $collection: $err');
+    }
   }).then((value) => value.count);
 }
 
@@ -646,12 +650,18 @@ Stream<List<T>> queryCollection<T>(Query collection, Serializer<T> serializer,
     query = query.limit(singleRecord ? 1 : limit);
   }
   return query.snapshots().handleError((err) {
-    print('Error querying $collection: $err');
+    if (kDebugMode) {
+      dev.log('Error querying $collection: $err');
+    }
   }).map((s) => s.docs
       .map(
         (d) => safeGet(
           () => serializers.deserializeWith(serializer, serializedData(d)),
-          (e) => print('Error serializing doc ${d.reference.path}:\n$e'),
+          (e) {
+            if (kDebugMode) {
+              dev.log('Error serializing doc ${d.reference.path}:\n$e');
+            }
+          },
         ),
       )
       .where((d) => d != null)
@@ -673,7 +683,11 @@ Future<List<T>> queryCollectionOnce<T>(
       .map(
         (d) => safeGet(
           () => serializers.deserializeWith(serializer, serializedData(d)),
-          (e) => print('Error serializing doc ${d.reference.path}:\n$e'),
+          (e) {
+            if (kDebugMode) {
+              dev.log('Error serializing doc ${d.reference.path}:\n$e');
+            }
+          },
         ),
       )
       .where((d) => d != null)
@@ -729,7 +743,11 @@ Future<FFFirestorePage<T>> queryCollectionPage<T>(
       .map(
         (d) => safeGet(
           () => serializers.deserializeWith(serializer, serializedData(d)),
-          (e) => print('Error serializing doc ${d.reference.path}:\n$e'),
+          (e) {
+            if (kDebugMode) {
+              dev.log('Error serializing doc ${d.reference.path}:\n$e');
+            }
+          },
         ),
       )
       .where((d) => d != null)

--- a/lib/flutter_flow/nav/serialization_util.dart
+++ b/lib/flutter_flow/nav/serialization_util.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:from_css_color/from_css_color.dart';
+import 'dart:developer' as dev;
+import 'package:flutter/foundation.dart';
 
 import '/backend/backend.dart';
 
@@ -93,7 +95,9 @@ String? serializeParam(
         return null;
     }
   } catch (e) {
-    print('Error serializing parameter: $e');
+    if (kDebugMode) {
+      dev.log('Error serializing parameter: $e');
+    }
     return null;
   }
 }
@@ -236,7 +240,9 @@ dynamic deserializeParam<T>(
         return null;
     }
   } catch (e) {
-    print('Error deserializing parameter: $e');
+    if (kDebugMode) {
+      dev.log('Error deserializing parameter: $e');
+    }
     return null;
   }
 }

--- a/lib/home/home_copy/home_copy_widget.dart
+++ b/lib/home/home_copy/home_copy_widget.dart
@@ -3,6 +3,8 @@ import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'dart:developer' as dev;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -78,7 +80,9 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                   size: 30.0,
                 ),
                 onPressed: () {
-                  print('IconButton pressed ...');
+                  if (kDebugMode) {
+                    dev.log('IconButton pressed ...');
+                  }
                 },
               ),
             ),

--- a/lib/home_copy/home_copy_widget.dart
+++ b/lib/home_copy/home_copy_widget.dart
@@ -3,6 +3,8 @@ import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import 'package:easy_debounce/easy_debounce.dart';
+import 'dart:developer' as dev;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -78,7 +80,9 @@ class _HomeCopyWidgetState extends State<HomeCopyWidget> {
                   size: 30.0,
                 ),
                 onPressed: () {
-                  print('IconButton pressed ...');
+                  if (kDebugMode) {
+                    dev.log('IconButton pressed ...');
+                  }
                 },
               ),
             ),

--- a/lib/profile_pages/profile_page/profile_page_widget.dart
+++ b/lib/profile_pages/profile_page/profile_page_widget.dart
@@ -4,6 +4,8 @@ import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/flutter_flow/custom_functions.dart' as functions;
+import 'dart:developer' as dev;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -192,7 +194,9 @@ class _ProfilePageWidgetState extends State<ProfilePageWidget> {
                                     child: AuthUserStreamWidget(
                                       builder: (context) => FFButtonWidget(
                                         onPressed: () {
-                                          print('Button pressed ...');
+                                          if (kDebugMode) {
+                                            dev.log('Button pressed ...');
+                                          }
                                         },
                                         text: (currentUserDocument
                                                     ?.listOfIllness


### PR DESCRIPTION
## Summary
- replace debug prints with `dev.log` guarded by `kDebugMode`
- swap print-based error handling for conditional logging in auth and backend utilities
- ensure serialization helpers log errors without affecting release builds

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689536ac13148322ab2d6d8952caac71